### PR TITLE
Fix steemconnect scope

### DIFF
--- a/src/services/steemconnect.js
+++ b/src/services/steemconnect.js
@@ -5,7 +5,7 @@ class SteemConnectService extends Client {
     super({
       app: process.env.VUE_APP_STEEMCONNECT_APP,
       callbackURL: location.protocol + "//" + location.host,
-      scope: ["login", "custom_json", "offline"]
+      scope: ["custom_json"]
     });
   }
 


### PR DESCRIPTION
I'm made a fix on the steemconnect scope cuz the latest version of SC is more strict about it and may break the login. The scope "login" should only be used if none of the posting operation is used, and the "offline" scope is only used if you want to generate refresh token, which is not the case as far as i understand.